### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Gatsby starter for creating a theme
 ```shell
 gatsby new my-theme https://github.com/ChristopherBiscardi/gatsby-starter-theme
 cd my-theme
-yarn workspace gatsby-theme-minimal-example develop
+yarn workspace example develop
 ```
 
 ## Layout


### PR DESCRIPTION
This PR fixes a small typo in README file, from `gatsby-theme-minimal-example` (which does not exist) to `example`