### PR TITLE
Adding node_modules to root .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache
 public
+node_modules

--- a/example/package.json
+++ b/example/package.json
@@ -10,9 +10,9 @@
     "build": "gatsby build"
   },
   "dependencies": {
-    "gatsby": "^2.1.32",
+    "gatsby": "^2.6.0",
     "gatsby-theme-minimal": "^1.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   }
 }

--- a/gatsby-theme-minimal/package.json
+++ b/gatsby-theme-minimal/package.json
@@ -5,6 +5,6 @@
   "author": "christopherbiscardi <chris@christopherbiscardi.com> (@chrisbiscardi)",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.75"
+    "gatsby": "^2.6.0"
   }
 }


### PR DESCRIPTION
Yarn installs node_modules in the root repository when running yarn install. node_modules directory should not be tracked in initial git commit when running `gatsby new <theme-name> <repo-name>`